### PR TITLE
Colors: add table of usages

### DIFF
--- a/components/@Docs/Colors/TableOfUsages/index.vue
+++ b/components/@Docs/Colors/TableOfUsages/index.vue
@@ -1,0 +1,136 @@
+<template>
+  <DocsTable
+    :columns="tableColumns"
+    :data="tableData"
+    class="clr-table-of-usages"
+  >
+    <template #title>
+      Daftar penggunaan warna default pada desain UI Produk JDS
+    </template>
+    <template #subtitle>
+      Klik pada kode hexa untuk mengcopy kode warnanya.
+    </template>
+
+    <!-- TEMPLATING PER COLUMN -->
+    <template v-slot:column-name="{ value: colorName, row }">
+      <div class="clr-table-of-usages__clr-name">
+        <i class="clr-dot" :style="{ backgroundColor: row.hex }"></i>
+        <span>
+          {{ colorName }}
+        </span>
+      </div>
+    </template>
+    <template v-slot:column-mainUsage="{ value: usages }">
+      <ul>
+        <li v-for="(u, i) in usages" :key="i">
+          {{ u }}
+        </li>
+      </ul>
+    </template>
+    <template v-slot:column-alternativeUsage="{ value: usages }">
+      <ul>
+        <li v-for="(u, i) in usages" :key="i">
+          {{ u }}
+        </li>
+      </ul>
+    </template>
+    <template v-slot:column-hex="{ value: hex }">
+      <div class="clr-table-of-usages__hex">
+        <span>
+          {{ hex }}
+        </span>
+        <IconPlaceholder />
+      </div>
+    </template>
+  </DocsTable>
+</template>
+
+<script>
+import IconPlaceholder from '../../../../components/@JDS/IconPlaceholder'
+import { ColorConfig, ColorVariant } from '../../../../config/colors/model'
+import colors from '../../../../config/colors'
+import DocsTable from '../../Table'
+
+export default {
+  components: {
+    DocsTable,
+    IconPlaceholder,
+  },
+  data() {
+    return {
+      colors: Object.freeze(colors),
+      tableColumns: [
+        {
+          header: 'Nama Warna',
+          prop: 'name',
+        },
+        {
+          header: 'Penggunaan Utama',
+          prop: 'mainUsage',
+        },
+        {
+          header: 'Penggunaan Alternatif',
+          prop: 'alternativeUsage',
+        },
+        {
+          header: 'Kode Hexa',
+          prop: 'hex',
+        },
+      ],
+    }
+  },
+  computed: {
+    tableData() {
+      const colorsToUse = {
+        Abu: ['900', '800', '600', '500', '400', '300'],
+        BiruAbu: ['900', '700'],
+        Hijau: ['600', '700', '800'],
+        Biru: ['600', '800'],
+        Ungu: ['700'],
+        Merah: ['900', '700'],
+        Kuning: ['700'],
+      }
+      const data = []
+      Object.entries(colorsToUse).forEach(([colorName, variants]) => {
+        const config = colors[colorName]
+        if (config instanceof ColorConfig) {
+          Object.values(colorsToUse[colorName]).forEach((v) => {
+            const variant = config.getColorVariant(v)
+            if (variant instanceof ColorVariant) {
+              data.push({
+                name: `${colorName}${variant.variantName}`,
+                mainUsage: variant.usages.main,
+                alternativeUsage: variant.usages.alternative,
+                hex: variant.hex,
+              })
+            }
+          })
+        }
+      })
+      return data
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.clr-table-of-usages {
+  &__clr-name {
+    display: flex;
+    align-items: center;
+
+    .clr-dot {
+      display: inline-block;
+      width: 1.5rem;
+      height: 1.5rem;
+      border-radius: 9999px;
+      margin-right: 1rem;
+    }
+  }
+  &__hex {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+</style>

--- a/components/@Docs/Table/index.vue
+++ b/components/@Docs/Table/index.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="docs-table">
+    <span v-if="$slots.title" class="text-hijau-500">
+      <slot name="title"></slot>
+    </span>
+    <p v-if="$slots.subtitle">
+      <slot name="subtitle"></slot>
+    </p>
+    <table style="width: 100%">
+      <thead class="docs-table__thead">
+        <tr class="docs-table__tr">
+          <th v-for="(col, i) in columns" :key="i" class="docs-table__th">
+            {{ col.header }}
+          </th>
+        </tr>
+      </thead>
+      <tbody class="docs-table__tbody">
+        <tr
+          v-for="(row, rowIndex) in data"
+          :key="rowIndex"
+          class="docs-table__tr"
+        >
+          <td
+            v-for="(column, columnIndex) in columns"
+            :key="columnIndex"
+            class="docs-table__td"
+          >
+            <slot
+              :name="`column-${column.prop}`"
+              v-bind="{
+                row,
+                column,
+                rowIndex,
+                columnIndex,
+                value: getCellValue(row, column, rowIndex, columnIndex),
+              }"
+            >
+              {{ getCellValue(row, column, rowIndex, columnIndex) }}
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+import _get from 'lodash/get'
+export default {
+  props: {
+    columns: {
+      type: Array,
+      default: () => [],
+    },
+    data: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  methods: {
+    getCellValue(row, column, rowIndex, columnIndex) {
+      if (typeof column.get === 'function') {
+        return column.get({ row, column, rowIndex, columnIndex })
+      }
+      return _get(row, column.prop)
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.docs-table {
+  text-align: left;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid #e0e0e0;
+  background-color: #fafafa;
+
+  &__thead {
+    .docs-table__th {
+      padding: 1rem 1.5rem;
+    }
+    .docs-table__th:first-child {
+      padding-left: 0;
+    }
+
+    .docs-table__th:last-child {
+      padding-right: 0;
+    }
+  }
+
+  &__tbody {
+    .docs-table__td {
+      vertical-align: baseline;
+      padding: 1rem 1.5rem;
+      border: 1px solid #ddd;
+      border: 1px solid #ddd;
+    }
+
+    .docs-table__td:first-child {
+      padding-left: 0;
+      border-left: none;
+    }
+
+    .docs-table__td:last-child {
+      padding-right: 0;
+      border-right: none;
+    }
+
+    .docs-table__tr:first-child {
+      .docs-table__td {
+        border-top: none;
+      }
+    }
+
+    .docs-table__tr:last-child {
+      .docs-table__td {
+        border-bottom: none;
+      }
+    }
+  }
+}
+</style>

--- a/config/colors/_abu.js
+++ b/config/colors/_abu.js
@@ -5,21 +5,18 @@ const mainVariantName = '900'
 
 export default createColorConfig(
   colorName,
-  new ColorVariant('50', '#FAFAFA')
-    .withReadabilityTestResult({
-      light: {
-        14: false,
-        16: false,
-        21: false,
-      },
-      dark: {
-        14: true,
-        16: true,
-        21: true,
-      },
-    })
-    .setMainUsage('Teks judul/title', 'Teks label input')
-    .setAlternativeUsage('Di semua tempat yang dibutuhkan'),
+  new ColorVariant('50', '#FAFAFA').withReadabilityTestResult({
+    light: {
+      14: false,
+      16: false,
+      21: false,
+    },
+    dark: {
+      14: true,
+      16: true,
+      21: true,
+    },
+  }),
   new ColorVariant('100', '#F5F5F5'),
   new ColorVariant('200', '#EEEEEE'),
   new ColorVariant('300', '#E0E0E0'),
@@ -29,4 +26,6 @@ export default createColorConfig(
   new ColorVariant('700', '#616161'),
   new ColorVariant('800', '#424242'),
   new ColorVariant('900', '#212121')
+    .setMainUsage('Teks judul/title', 'Teks label input')
+    .setAlternativeUsage('Di semua tempat yang dibutuhkan')
 ).setMainColorVariant(mainVariantName)

--- a/content/desain/warna.md
+++ b/content/desain/warna.md
@@ -254,3 +254,5 @@ Tujuan penggunaan warna spesifik untuk kondisi atau komponen tertentu adalah unt
 Sebagai informasi tambahan kombinasi penggunaan warna dibawah ini adalah penggunaan warna default, jika memungkinkan, desainer dapat menggunakan kombinasi warna berbeda sesuai keinginannya.
 
 Berikut adalah petunjuk dan cara untuk penggunaan setiap warna di Sistem Warna JDS. 
+
+<table-of-usages></table-of-usages>

--- a/pages/dok/desain/warna.vue
+++ b/pages/dok/desain/warna.vue
@@ -16,6 +16,8 @@ export default {
       ),
     ColorPalette: () =>
       import('../../../components/@Docs/Colors/PaletteByColorName'),
+    TableOfUsages: () =>
+      import('../../../components/@Docs/Colors/TableOfUsages'),
   },
   nuxtI18n: {
     paths: {


### PR DESCRIPTION
Added:
- Abstracted table for use in docs
- Table of color usage component
- Insert Table of color usage component in `warna.md`

Modified:
- Add an example on setting main and alternative usage per color variant in color config.