### PR TITLE
[Fix] Colors: assign color name to variant model

### DIFF
--- a/components/@Docs/Colors/ReadabilityTest/index.vue
+++ b/components/@Docs/Colors/ReadabilityTest/index.vue
@@ -26,7 +26,7 @@
     <div class="clr-readability__info">
       <div>
         <label>Nama</label>
-        <p>{{ variantName }}</p>
+        <p>{{ name }}</p>
       </div>
       <div>
         <label>Hex</label>
@@ -56,9 +56,13 @@ export default {
     return {}
   },
   computed: {
-    variantName() {
+    name() {
       if (this.colorVariant instanceof ColorVariant) {
-        return this.colorVariant.variantName
+        const { colorName, variantName } = this.colorVariant
+        if (variantName === 'default') {
+          return colorName
+        }
+        return `${colorName}${variantName}`
       }
       return null
     },

--- a/config/colors/model.js
+++ b/config/colors/model.js
@@ -44,12 +44,14 @@ export function ColorConfig(colorName) {
   return this
 }
 
-ColorConfig.prototype.addColorVariant = function (colorVariant) {
+ColorConfig.prototype.addColorVariant = function (colorName, colorVariant) {
   if (colorVariant instanceof ColorVariant) {
     if (colorVariant.variantName in this.variants) {
       throw new Error(`${colorVariant.variantName} already defined`)
     }
-    this.variants[colorVariant.variantName] = colorVariant
+    this.variants[colorVariant.variantName] = Object.assign(colorVariant, {
+      colorName,
+    })
     return this
   }
   throw new Error('colorVariant must be an instanceof ColorVariant')
@@ -75,7 +77,7 @@ export function createColorConfig(colorName, ...variants) {
   const config = new ColorConfig(colorName)
   if (Array.isArray(variants) && variants.length) {
     variants.forEach((v) => {
-      config.addColorVariant(v)
+      config.addColorVariant(colorName, v)
     })
   }
   return config


### PR DESCRIPTION
Assign `colorName` to `ColorVariant` object model so each color variant wont lose track of its base color name.

Example case:
Before fix:
_variant lose its base color name_
![image](https://user-images.githubusercontent.com/20709202/94092792-dea86d80-fe45-11ea-9c7d-3220a87a317e.png)


After fix:
_variant keep its base color name as its property_
![image](https://user-images.githubusercontent.com/20709202/94092814-ebc55c80-fe45-11ea-8ab2-ed037eda2539.png)
