### PR TITLE
Setup: add global components for markdown content

### DIFF
--- a/components/@Docs/ContentTitleDivider/index.vue
+++ b/components/@Docs/ContentTitleDivider/index.vue
@@ -1,0 +1,11 @@
+<template functional>
+  <hr class="content-title-divider" />
+</template>
+
+<style lang="scss" scoped>
+.content-title-divider {
+  display: block;
+  width: 100%;
+  margin-top: 48px;
+}
+</style>

--- a/components/@Docs/Example/BoxedExample.vue
+++ b/components/@Docs/Example/BoxedExample.vue
@@ -1,0 +1,38 @@
+<template functional>
+  <div class="boxed-example">
+    <h4 v-if="$slots.title" class="boxed-example__title">
+      <slot name="title"></slot>
+    </h4>
+    <p v-if="$slots.subtitle" class="boxed-example__subtitle">
+      <slot name="subtitle"></slot>
+    </p>
+    <div class="boxed-example__content">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  //
+}
+</script>
+
+<style lang="scss" scoped>
+.boxed-example {
+  text-align: left;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid #e0e0e0;
+  background-color: #fafafa;
+
+  &__title {
+    color: colors.$hijau-500;
+  }
+
+  &__subtitle {
+    font-size: 14px;
+    color: colors.$abu-700;
+  }
+}
+</style>

--- a/components/@Docs/Example/OpinionatedExample.vue
+++ b/components/@Docs/Example/OpinionatedExample.vue
@@ -1,0 +1,91 @@
+<template>
+  <JDSCard
+    flat
+    block
+    :class="[
+      'opinionated-example-card',
+      good && 'is-good',
+      bad && 'is-bad',
+      warned && 'is-warned',
+    ]"
+  >
+    <div class="opinionated-example-card__illust">
+      <slot name="example"></slot>
+    </div>
+    <div class="opinionated-example-card__desc">
+      <IconPlaceholder style="margin-right: 1rem; flex: none" />
+      <p>
+        <slot name="description"></slot>
+      </p>
+    </div>
+  </JDSCard>
+</template>
+
+<script>
+import IconPlaceholder from '../../@JDS/IconPlaceholder'
+import JDSCard from '../../@JDS/Card'
+export default {
+  components: {
+    JDSCard,
+    IconPlaceholder,
+  },
+  props: {
+    good: {
+      type: Boolean,
+    },
+    bad: {
+      type: Boolean,
+    },
+    warned: {
+      type: Boolean,
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@use '~/assets/stylesheet/jds-design-system/variables/colors';
+
+.opinionated-example-card {
+  height: 100%;
+  display: flex !important;
+  flex-flow: column;
+
+  &__illust {
+    flex: none;
+    padding: 1.5rem;
+    background-color: colors.$abu-200;
+  }
+
+  &__desc {
+    flex: 1 1 100%;
+    display: flex;
+    align-items: baseline;
+    padding: 1.5rem;
+    border-top-width: 3px !important;
+    border-bottom-left-radius: inherit;
+    border-bottom-right-radius: inherit;
+
+    font-size: 14px;
+    color: colors.$abu-800;
+  }
+
+  &.is-good {
+    .opinionated-example-card__desc {
+      border: 1px solid colors.$hijau-600;
+    }
+  }
+
+  &.is-bad {
+    .opinionated-example-card__desc {
+      border: 1px solid colors.$merah-600;
+    }
+  }
+
+  &.is-warned {
+    .opinionated-example-card__desc {
+      border: 1px solid colors.$kuning-800;
+    }
+  }
+}
+</style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -25,10 +25,10 @@ export default {
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
   },
   css: [
-    '../assets/stylesheet/app/main.scss',
-    '../assets/stylesheet/jds-design-system/main.scss',
+    '~/assets/stylesheet/app/main.scss',
+    '~/assets/stylesheet/jds-design-system/main.scss',
   ],
-  plugins: [],
+  plugins: ['~/plugins/markdown-content-components.js'],
   // @nuxt/components ============================================================
   // disable auto import component
   components: false,
@@ -58,6 +58,13 @@ export default {
     liveEdit: false,
     markdown: {
       rehypePlugins: [['rehype-add-classes', rehypeOptions]],
+    },
+  },
+  tailwindcss: {
+    config: {
+      corePlugins: {
+        // preflight: false,
+      },
     },
   },
   build: {

--- a/plugins/markdown-content-components.js
+++ b/plugins/markdown-content-components.js
@@ -1,0 +1,12 @@
+import Vue from 'vue'
+import BoxedExample from '../components/@Docs/Example/BoxedExample.vue'
+import OpinionatedExample from '../components/@Docs/Example/OpinionatedExample'
+import ContentTitleDivider from '../components/@Docs/ContentTitleDivider'
+
+const components = {
+  BoxedExample,
+  OpinionatedExample,
+  ContentTitleDivider,
+}
+
+Object.entries(components).forEach(([name, c]) => Vue.component(name, c))


### PR DESCRIPTION
Added:
- add global components to use in markdown content (`*.md`):
    - BoxedExample
    - OpionionatedExample
    - ContentTitleDivider
