### PR TITLE
use scss variables to define element color; refactor Table component;

### DIFF
--- a/components/@Docs/Colors/ReadabilityTest/index.vue
+++ b/components/@Docs/Colors/ReadabilityTest/index.vue
@@ -92,7 +92,7 @@ export default {
 
 <style lang="scss" scoped>
 .clr-readability {
-  display: inline-block;
+  display: block;
   border-radius: 0.5rem;
 
   &__grids {
@@ -134,6 +134,7 @@ export default {
     display: flex;
     justify-content: space-between;
     padding: 0.5rem 1rem;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
 
     label {
       color: #9e9e9e;

--- a/components/@Docs/Colors/TableOfUsages/index.vue
+++ b/components/@Docs/Colors/TableOfUsages/index.vue
@@ -114,6 +114,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@use '~/assets/stylesheet/jds-design-system/variables/colors';
+
 .clr-table-of-usages {
   &__clr-name {
     display: flex;
@@ -131,6 +133,12 @@ export default {
     display: flex;
     justify-content: space-between;
     align-items: center;
+  }
+
+  * {
+    color: colors.$abu-700;
+    font-weight: normal !important;
+    font-size: 1rem !important;
   }
 }
 </style>

--- a/components/@Docs/Table/index.vue
+++ b/components/@Docs/Table/index.vue
@@ -1,47 +1,39 @@
 <template>
-  <div class="docs-table">
-    <span v-if="$slots.title" class="text-hijau-500">
-      <slot name="title"></slot>
-    </span>
-    <p v-if="$slots.subtitle">
-      <slot name="subtitle"></slot>
-    </p>
-    <table style="width: 100%">
-      <thead class="docs-table__thead">
-        <tr class="docs-table__tr">
-          <th v-for="(col, i) in columns" :key="i" class="docs-table__th">
-            {{ col.header }}
-          </th>
-        </tr>
-      </thead>
-      <tbody class="docs-table__tbody">
-        <tr
-          v-for="(row, rowIndex) in data"
-          :key="rowIndex"
-          class="docs-table__tr"
+  <table class="docs-table" style="width: 100%">
+    <thead class="docs-table__thead">
+      <tr class="docs-table__tr">
+        <th v-for="(col, i) in columns" :key="i" class="docs-table__th">
+          {{ col.header }}
+        </th>
+      </tr>
+    </thead>
+    <tbody class="docs-table__tbody">
+      <tr
+        v-for="(row, rowIndex) in data"
+        :key="rowIndex"
+        class="docs-table__tr"
+      >
+        <td
+          v-for="(column, columnIndex) in columns"
+          :key="columnIndex"
+          class="docs-table__td"
         >
-          <td
-            v-for="(column, columnIndex) in columns"
-            :key="columnIndex"
-            class="docs-table__td"
+          <slot
+            :name="`column-${column.prop}`"
+            v-bind="{
+              row,
+              column,
+              rowIndex,
+              columnIndex,
+              value: getCellValue(row, column, rowIndex, columnIndex),
+            }"
           >
-            <slot
-              :name="`column-${column.prop}`"
-              v-bind="{
-                row,
-                column,
-                rowIndex,
-                columnIndex,
-                value: getCellValue(row, column, rowIndex, columnIndex),
-              }"
-            >
-              {{ getCellValue(row, column, rowIndex, columnIndex) }}
-            </slot>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+            {{ getCellValue(row, column, rowIndex, columnIndex) }}
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </template>
 
 <script>
@@ -69,12 +61,19 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@use '~/assets/stylesheet/jds-design-system/variables/colors';
+
 .docs-table {
   text-align: left;
-  padding: 1rem;
-  border-radius: 1rem;
-  border: 1px solid #e0e0e0;
-  background-color: #fafafa;
+
+  &__title {
+    color: colors.$hijau-500;
+  }
+
+  &__subtitle {
+    font-size: 14px;
+    color: colors.$abu-700;
+  }
 
   &__thead {
     .docs-table__th {


### PR DESCRIPTION
Modified:
- Refactor `Table` component
    Use `Table` inside `BoxedExample` to render title and subtitle, instead of defining those attribute inside `Table` directly.
- Use generated SCSS variable in defining element color